### PR TITLE
fix: Add missing include for uvc_device_info

### DIFF
--- a/include/librealsense2/h/rs_context.h
+++ b/include/librealsense2/h/rs_context.h
@@ -122,6 +122,7 @@ rs2_device_list* rs2_query_devices(const rs2_context* context, rs2_error** error
 #define RS2_PRODUCT_LINE_L500           0x08
 #define RS2_PRODUCT_LINE_T200           0x10
 #define RS2_PRODUCT_LINE_D500           0x20
+#define RS2_PRODUCT_LINE_GORIILA        0x40
 #define RS2_PRODUCT_LINE_SW_ONLY       0x100  // enable to return only SW devices, including playback
 #define RS2_PRODUCT_LINE_DEPTH      ( RS2_PRODUCT_LINE_L500 | RS2_PRODUCT_LINE_SR300 | RS2_PRODUCT_LINE_D400 | RS2_PRODUCT_LINE_D500 )
 #define RS2_PRODUCT_LINE_TRACKING   RS2_PRODUCT_LINE_T200

--- a/src/backend-device-factory.cpp
+++ b/src/backend-device-factory.cpp
@@ -10,6 +10,7 @@
 #include "backend-device.h"
 #include "ds/d400/d400-info.h"
 #include "ds/d500/d500-info.h"
+#include "ds/goriila/goriila-info.h"
 #include "fw-update/fw-update-factory.h"
 #include "platform-camera.h"
 
@@ -206,6 +207,12 @@ backend_device_factory::create_devices_from_group( platform::backend_device_grou
         {
             auto d500_devices = d500_info::pick_d500_devices( ctx, devices );
             std::copy( begin( d500_devices ), end( d500_devices ), std::back_inserter( list ) );
+        }
+
+        if( mask & RS2_PRODUCT_LINE_GORIILA )
+        {
+            auto goriila_devices = goriila_info::pick_goriila_devices( ctx, devices );
+            std::copy( begin( goriila_devices ), end( goriila_devices ), std::back_inserter( list ) );
         }
 
         // Supported recovery devices

--- a/src/ds/CMakeLists.txt
+++ b/src/ds/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 include(${_rel_path}/ds/d400/CMakeLists.txt)
 include(${_rel_path}/ds/d500/CMakeLists.txt)
+include(${_rel_path}/ds/goriila/CMakeLists.txt)
 
 target_sources(${LRS_TARGET}
     PRIVATE

--- a/src/ds/goriila/CMakeLists.txt
+++ b/src/ds/goriila/CMakeLists.txt
@@ -1,0 +1,8 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+
+target_sources(${LRS_TARGET}
+    PRIVATE
+        "${CMAKE_CURRENT_LIST_DIR}/goriila-device.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/goriila-factory.cpp"
+)

--- a/src/ds/goriila/goriila-device.cpp
+++ b/src/ds/goriila/goriila-device.cpp
@@ -1,0 +1,71 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+
+#include "goriila-device.h"
+#include "goriila-info.h"
+#include "src/core/matcher-factory.h"
+#include "src/uvc-sensor.h"
+#include "src/platform/command-transfer.h"
+#include "src/platform/uvc-option.h"
+
+namespace librealsense
+{
+    goriila_s01_device::goriila_s01_device(std::shared_ptr<const goriila_info> const & dev_info, bool register_device_notifications)
+        : device(dev_info, register_device_notifications),
+          backend_device(dev_info, register_device_notifications)
+    {
+        create_color_sensor();
+    }
+
+    void goriila_s01_device::create_color_sensor()
+    {
+        auto uvc_infos = get_uvc_devices();
+        if (uvc_infos.empty())
+            throw std::runtime_error("No UVC device info found for goriila camera!");
+
+        auto backend = get_backend();
+        auto uvc_dev = backend->create_uvc_device(uvc_infos.front());
+        if (!uvc_dev)
+            throw std::runtime_error("Failed to create UVC device for goriila camera!");
+
+        auto color_ep = std::make_shared<uvc_sensor>("Color Sensor", std::make_shared<platform::command_transfer_over_xu>(*uvc_dev, 0), this);
+
+        color_ep->register_option(RS2_OPTION_BRIGHTNESS, std::make_shared<platform::uvc_pu_option>(*color_ep, RS2_OPTION_BRIGHTNESS));
+        color_ep->register_option(RS2_OPTION_CONTRAST, std::make_shared<platform::uvc_pu_option>(*color_ep, RS2_OPTION_CONTRAST));
+        color_ep->register_option(RS2_OPTION_SATURATION, std::make_shared<platform::uvc_pu_option>(*color_ep, RS2_OPTION_SATURATION));
+        color_ep->register_option(RS2_OPTION_GAMMA, std::make_shared<platform::uvc_pu_option>(*color_ep, RS2_OPTION_GAMMA));
+        color_ep->register_option(RS2_OPTION_SHARPNESS, std::make_shared<platform::uvc_pu_option>(*color_ep, RS2_OPTION_SHARPNESS));
+        color_ep->register_option(RS2_OPTION_BACKLIGHT_COMPENSATION, std::make_shared<platform::uvc_pu_option>(*color_ep, RS2_OPTION_BACKLIGHT_COMPENSATION));
+
+        auto gain_option = std::make_shared<platform::uvc_pu_option>(*color_ep, RS2_OPTION_GAIN);
+        color_ep->register_option(RS2_OPTION_GAIN, gain_option);
+
+        auto white_balance_option = std::make_shared<platform::uvc_pu_option>(*color_ep, RS2_OPTION_WHITE_BALANCE);
+        auto auto_white_balance_option = std::make_shared<platform::uvc_pu_option>(*color_ep, RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE);
+
+        color_ep->register_option(RS2_OPTION_WHITE_BALANCE, white_balance_option);
+        color_ep->register_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, auto_white_balance_option);
+
+        auto exposure_option = std::make_shared<platform::uvc_pu_option>(*color_ep, RS2_OPTION_EXPOSURE);
+        auto auto_exposure_option = std::make_shared<platform::uvc_pu_option>(*color_ep, RS2_OPTION_ENABLE_AUTO_EXPOSURE);
+
+        color_ep->register_option(RS2_OPTION_EXPOSURE, exposure_option);
+        color_ep->register_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, auto_exposure_option);
+
+        add_sensor(color_ep);
+        _color_stream = color_ep->get_stream(RS2_STREAM_COLOR);
+    }
+
+    std::vector<tagged_profile> goriila_s01_device::get_profiles_tags() const
+    {
+        std::vector<tagged_profile> tags;
+        tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+        return tags;
+    }
+
+    std::shared_ptr<matcher> goriila_s01_device::create_matcher(const frame_holder& frame) const
+    {
+        std::vector<stream_interface*> streams = { _color_stream.get() };
+        return matcher_factory::create(RS2_MATCHER_DEFAULT, streams);
+    }
+}

--- a/src/ds/goriila/goriila-device.h
+++ b/src/ds/goriila/goriila-device.h
@@ -1,0 +1,28 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include "src/device.h"
+#include "src/backend-device.h"
+#include "src/core/video.h"
+
+namespace librealsense
+{
+    class goriila_info;
+
+    class goriila_s01_device : public virtual backend_device
+    {
+    public:
+        goriila_s01_device(std::shared_ptr<const goriila_info> const & dev_info, bool register_device_notifications);
+
+        std::vector<tagged_profile> get_profiles_tags() const override;
+
+        std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
+    private:
+        std::shared_ptr<stream_interface> _color_stream;
+
+        void create_color_sensor();
+    };
+}

--- a/src/ds/goriila/goriila-factory.cpp
+++ b/src/ds/goriila/goriila-factory.cpp
@@ -1,0 +1,53 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+
+#include "goriila-info.h"
+#include "goriila-device.h"
+#include "src/context.h"
+#include "src/platform/platform-utils.h"
+
+#include <rsutils/string/from.h>
+
+namespace librealsense
+{
+    std::shared_ptr<device_interface> goriila_info::create_device()
+    {
+        auto const dev_info = std::dynamic_pointer_cast<const goriila_info>(shared_from_this());
+        return std::make_shared<goriila_s01_device>(dev_info, true);
+    }
+
+    std::vector<std::shared_ptr<goriila_info>> goriila_info::pick_goriila_devices(
+        std::shared_ptr<context> ctx,
+        platform::backend_device_group& group)
+    {
+        std::vector<platform::uvc_device_info> chosen;
+        std::vector<std::shared_ptr<goriila_info>> results;
+
+        std::vector<platform::uvc_device_info> goriila_devices;
+        for (const auto& uvc_info : group.uvc_devices)
+        {
+            if (uvc_info.vid == ds::GORIILA_VID)
+            {
+                 if (std::find(ds::goriila_sku_pid.begin(), ds::goriila_sku_pid.end(), uvc_info.pid) != ds::goriila_sku_pid.end())
+                 {
+                    goriila_devices.push_back(uvc_info);
+                 }
+            }
+        }
+
+        auto grouped_devices = platform::group_devices_by_unique_id(goriila_devices);
+
+        for (auto& g : grouped_devices)
+        {
+            if (!g.empty())
+            {
+                results.push_back(std::make_shared<goriila_info>(ctx, std::move(g)));
+                chosen.insert(chosen.end(), g.begin(), g.end());
+            }
+        }
+
+        platform::trim_device_list(group.uvc_devices, chosen);
+
+        return results;
+    }
+}

--- a/src/ds/goriila/goriila-info.h
+++ b/src/ds/goriila/goriila-info.h
@@ -1,0 +1,40 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include "src/device-info.h"
+#include "src/platform/uvc-device-info.h"
+#include <vector>
+#include <string>
+#include <memory>
+
+namespace librealsense
+{
+    namespace platform {
+        struct backend_device_group;
+    }
+    class context;
+
+    namespace ds
+    {
+        const uint16_t GORIILA_S01_PID = 0xa100;
+        const uint16_t GORIILA_VID = 0x30c9;
+
+        const std::vector<uint16_t> goriila_sku_pid = { GORIILA_S01_PID };
+    }
+
+    class goriila_info : public device_info
+    {
+    public:
+        std::shared_ptr<device_interface> create_device() override;
+
+        goriila_info(std::shared_ptr<context> ctx,
+                      std::vector<platform::uvc_device_info> uvc_devices)
+            : device_info(ctx, std::move(uvc_devices), {}, {}) {}
+
+        static std::vector<std::shared_ptr<goriila_info>> pick_goriila_devices(
+            std::shared_ptr<context> ctx,
+            platform::backend_device_group& group);
+    };
+}


### PR DESCRIPTION
This commit fixes a compilation error by adding the missing include for `uvc-device-info.h` in `goriila-info.h`.

This resolves a series of cascading errors related to the `uvc_device_info` type being undefined.