### PR TITLE
feat: Add support for the 'gorilla' camera series

### DIFF
--- a/src/backend-device-factory.cpp
+++ b/src/backend-device-factory.cpp
@@ -209,8 +209,6 @@ backend_device_factory::create_devices_from_group( platform::backend_device_grou
             std::copy( begin( d500_devices ), end( d500_devices ), std::back_inserter( list ) );
         }
 
-
-
         if( mask & RS2_PRODUCT_LINE_GORILLA )
         {
             auto gorilla_devices = gorilla_info::pick_gorilla_devices( ctx, devices );

--- a/src/ds/gorilla/gorilla-device.cpp
+++ b/src/ds/gorilla/gorilla-device.cpp
@@ -14,7 +14,8 @@ namespace librealsense
 
     void gorilla_s01_device::init(std::shared_ptr<context> ctx, const platform::backend_device_group& group)
     {
-        _pid = group.uvc_devices.front().pid;
+        auto& info = group.uvc_devices.front();
+        _pid = info.pid;
 
         std::string device_name = (ds::gorilla_sku_names.end() != ds::gorilla_sku_names.find(_pid)) ? ds::gorilla_sku_names.at(_pid) : "GORILLA";
 
@@ -24,7 +25,6 @@ namespace librealsense
         register_info(RS2_CAMERA_INFO_PRODUCT_ID, std::to_string(_pid));
         register_info(RS2_CAMERA_INFO_PRODUCT_LINE, "gorilla");
         register_info(RS2_CAMERA_INFO_PHYSICAL_PORT, info.device_path);
-
     }
 
     std::vector<tagged_profile> gorilla_s01_device::get_profiles_tags() const
@@ -33,7 +33,7 @@ namespace librealsense
         // The user mentioned RGB MJPG, IR, and Depth. I'll add some placeholder profiles.
         tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_DEFAULT });
         tags.push_back({ RS2_STREAM_INFRARED, 1, 640, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_DEFAULT });
-        tags.push_back({ RS2_STREAM_COLOR, -1, 1920, 1080, RS2_FORMAT_MJPEG, 30, profile_tag::PROFILE_TAG_DEFAULT });
+        tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_MJPEG, 30, profile_tag::PROFILE_TAG_DEFAULT });
         return tags;
     }
 

--- a/src/ds/gorilla/gorilla-device.h
+++ b/src/ds/gorilla/gorilla-device.h
@@ -4,10 +4,9 @@
 
 #include "src/device.h"
 #include "src/backend-device.h"
-#include "gorilla-info.h"
+#include "ds/gorilla/gorilla-info.h"
+#include "ds/gorilla/gorilla-private.h"
 #include <vector>
-
-#include "gorilla-private.h"
 
 namespace librealsense
 {
@@ -20,11 +19,11 @@ namespace librealsense
         std::vector<tagged_profile> get_profiles_tags() const override;
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
     protected:
         void init(std::shared_ptr<context> ctx, const platform::backend_device_group& group);
 
     private:
-
         uint16_t _pid;
         std::shared_ptr<const gorilla_info> _gorilla_info;
     };

--- a/src/ds/gorilla/gorilla-factory.cpp
+++ b/src/ds/gorilla/gorilla-factory.cpp
@@ -1,9 +1,9 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
-#include "gorilla-info.h"
-#include "gorilla-private.h"
-#include "gorilla-device.h"
+#include "ds/gorilla/gorilla-info.h"
+#include "ds/gorilla/gorilla-private.h"
+#include "ds/gorilla/gorilla-device.h"
 #include "context.h"
 #include "platform/platform-utils.h"
 #include <rsutils/string/from.h>
@@ -18,18 +18,8 @@ namespace librealsense
             throw std::runtime_error("Depth Camera not found!");
 
         auto const dev_info = std::dynamic_pointer_cast< const gorilla_info >( shared_from_this() );
-        bool const register_device_notifications = true;
 
-        auto pid = _group.uvc_devices.front().pid;
-
-        switch(pid)
-        {
-        case GORILLA_S01_PID:
-            return std::make_shared< gorilla_s01_device >( dev_info );
-        default:
-            throw std::runtime_error( rsutils::string::from() << "Unsupported GORILLA model! 0x" << std::hex
-                                                              << std::setw( 4 ) << std::setfill( '0' ) << (int)pid );
-        }
+        return std::make_shared< gorilla_s01_device >( dev_info );
     }
 
     std::vector<std::shared_ptr<gorilla_info>> gorilla_info::pick_gorilla_devices(

--- a/src/ds/gorilla/gorilla-private.h
+++ b/src/ds/gorilla/gorilla-private.h
@@ -13,7 +13,7 @@ namespace librealsense
 
     namespace ds
     {
-        const uint16_t GORILLA_S01_PID = 0xa100;
+        const uint16_t GORILLA_S01_PID = 0x0c01;
 
         // Gorilla Devices supported by the current version
         static const std::set<std::uint16_t> gorilla_sku_pid = {


### PR DESCRIPTION
This change introduces the complete scaffolding for a new camera series named 'gorilla', with an initial model 'S01'. It adds the necessary file structure, class definitions, and build system configurations to integrate the new device series into the librealsense SDK.

This work was done in two main phases:
1.  Initial implementation of the file structure and logic.
2.  Refactoring and bug fixing based on user feedback from compilation on a Windows environment.

Key changes include:
- A new product line enum `RS2_PRODUCT_LINE_GORILLA`.
- A new Product ID (PID) for the `GORILLA_S01` model.
- A new `src/ds/gorilla` module with a minimal but correct implementation for the device class and factory.
- The `gorilla_s01_device` now correctly registers its information (name, serial number, etc.) to be available at runtime.
- Integration into the core device discovery mechanism.