### PR TITLE
Fix compilation errors in Gorilla device implementation

### DIFF
--- a/src/ds/gorilla/gorilla-color.cpp
+++ b/src/ds/gorilla/gorilla-color.cpp
@@ -28,7 +28,7 @@ namespace librealsense
     };
 
     gorilla_color::gorilla_color(std::shared_ptr<const gorilla_info> const & dev_info)
-        : gorilla_device(dev_info), device(dev_info),
+        : device(dev_info), backend_device(dev_info), gorilla_device(dev_info),
           _color_stream(new stream(RS2_STREAM_COLOR))
     {
         create_color_device(dev_info->get_context(), dev_info->get_group());

--- a/src/ds/gorilla/gorilla-color.h
+++ b/src/ds/gorilla/gorilla-color.h
@@ -25,6 +25,7 @@ namespace librealsense
         void create_color_device(std::shared_ptr<context> ctx, const platform::backend_device_group& group);
         uint8_t _color_device_idx = -1;
 
+    friend class gorilla_color_sensor;
         friend class d400_color_sensor;
         friend class ds_color_common;
     };


### PR DESCRIPTION
This commit resolves three C++ compilation errors that occurred when building the custom Gorilla device SDK extension.

The fixes include:
1. Correcting the constructor for the `gorilla_color` class to properly initialize all its virtual base classes (`device`, `backend_device`, `gorilla_device`). This resolves the `C2512` errors related to missing default constructors.
2. Declaring `gorilla_color_sensor` as a `friend` of the `gorilla_color` class. This grants the sensor class the necessary permissions to access protected members of its owning device, fixing the `C2248` access violation error.